### PR TITLE
Exclude from suggestion in App Editor of map.apps Manger

### DIFF
--- a/src/main/js/bundles/mapapps-github-manager/manifest.json
+++ b/src/main/js/bundles/mapapps-github-manager/manifest.json
@@ -15,6 +15,9 @@
         "apprt-binding": "^4.3.0",
         "apprt-vuetify": "^4.3.0"
     },
+    "editor": {
+        "suggest": false
+    },
     "CSS-Themes-Extension": [
         {
             "name": "*",


### PR DESCRIPTION
With https://conterrade.atlassian.net/browse/MAPAPPS-6043 , bundles will be excluded from the suggestion list of the app editor in the map.apps manager. This is controlled by a flag in the bundle metadata / manifest.json.
This PR is to provide this flag to the mapapps-github-manager to be excluded as well